### PR TITLE
improves version reporting

### DIFF
--- a/hexrd/__init__.py
+++ b/hexrd/__init__.py
@@ -24,3 +24,5 @@
 # the Free Software Foundation, Inc., 59 Temple Place, Suite 330,
 # Boston, MA 02111-1307 USA or visit <http://www.gnu.org/licenses/>.
 # ============================================================
+
+__version__ = '0.0.0'

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,15 @@ for dirpath, dirnames, filenames in os.walk('.'):
     else:
         del(dirnames[:])
 
+with open('hexrd/__init__.py') as f:
+    for line in f:
+        if line[:11] == '__version__':
+            exec(line)
+            break
+
 setup(
     name = 'hexrd',
-    version = '0.0.0',
+    version = __version__,
     author = 'Joel Bernier, et al.',
     author_email = 'bernier2@llnl.gov',
     description = 'High energy diffraction microscopy',


### PR DESCRIPTION
Provides a "**version**" variable, so users of the library can do:

import hexrd
print hexrd.**version**

This is common practice for python packages.

Also, setup.py extracts the version information from hexrd/**init**.py, so we don't have to change the information in multiple locations.
