### PR TITLE
adds hexrd script for launching main program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+build
 _build
 *.pyc

--- a/scripts/hexrd
+++ b/scripts/hexrd
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+import sys
+
+from hexrd.GUI import mainApp
+
+
+mainApp.execute(*sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,24 @@
 # ============================================================
-# Copyright (c) 2012, Lawrence Livermore National Security, LLC. 
-# Produced at the Lawrence Livermore National Laboratory. 
-# Written by Joel Bernier <bernier2@llnl.gov> and others. 
-# LLNL-CODE-529294. 
+# Copyright (c) 2012, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by Joel Bernier <bernier2@llnl.gov> and others.
+# LLNL-CODE-529294.
 # All rights reserved.
-# 
+#
 # This file is part of HEXRD. For details on dowloading the source,
 # see the file COPYING.
-# 
+#
 # Please also see the file LICENSE.
-# 
+#
 # This program is free software; you can redistribute it and/or modify it under the
 # terms of the GNU Lesser General Public License (as published by the Free Software
 # Foundation) version 2.1 dated February 1999.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY 
-# or FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the 
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Lesser General Public
 # License along with this program (see file LICENSE); if not, write to
 # the Free Software Foundation, Inc., 59 Temple Place, Suite 330,
@@ -51,6 +51,10 @@ with open('hexrd/__init__.py') as f:
             exec(line)
             break
 
+scripts = [
+    'scripts/hexrd'
+    ]
+
 setup(
     name = 'hexrd',
     version = __version__,
@@ -66,5 +70,6 @@ setup(
         'scipy (>=0.7.0)',
         'wxpython (>= 2.8)',
         ),
+    scripts = scripts,
 )
 


### PR DESCRIPTION
This pull request adds a "scripts" subdirectory for executables, and a "hexrd" executable for the main program. The setup.py file is modified to inform distutils about these scripts, so they can be installed in an appropriate location (which may need to be added to the user's PATH for convenience.)
