### PR TITLE
fix sizers to run with wx-2.9.4

### DIFF
--- a/hexrd/GUI/canvasUtilities.py
+++ b/hexrd/GUI/canvasUtilities.py
@@ -149,8 +149,8 @@ class cmapPanel(wx.Panel):
         #
         #  colormap sizer
         #
-        nrow = 1; ncol = 3; padx = 5; pady = 5
-	self.cmSizer = wx.FlexGridSizer(nrow, ncol, padx, pady)
+        nrow = 3; ncol = 3; padx = 5; pady = 5
+        self.cmSizer = wx.FlexGridSizer(nrow, ncol, padx, pady)
         
         self.cmSizer.Add(self.cmap_lab, 0, wx.EXPAND | wx.ALIGN_RIGHT)
         self.cmSizer.Add(self.cmap_cho, 0, wx.EXPAND | wx.ALIGN_RIGHT)
@@ -164,8 +164,8 @@ class cmapPanel(wx.Panel):
         self.cmSizer.Add(self.cmax_txt, 0, wx.EXPAND | wx.ALIGN_RIGHT)
         self.cmSizer.Add(self.cmOver_box, 0, wx.EXPAND | wx.ALIGN_RIGHT)
 	
-	self.sizer = wx.BoxSizer(wx.VERTICAL)
-	self.sizer.Add(self.tbarSizer, 0, wx.EXPAND|wx.ALIGN_CENTER)
+        self.sizer = wx.BoxSizer(wx.VERTICAL)
+        self.sizer.Add(self.tbarSizer, 0, wx.EXPAND|wx.ALIGN_CENTER)
         self.sizer.Add(self.cmSizer,   0, wx.EXPAND|wx.ALIGN_RIGHT)
 
 	return

--- a/hexrd/GUI/detectorPanel.py
+++ b/hexrd/GUI/detectorPanel.py
@@ -277,7 +277,7 @@ class detectorPanel(wx.Panel):
         #
         #  Geometry sizer
         #
-        nrow = 10; ncol = 2; padx = 5; pady = 5
+        nrow = 12; ncol = 2; padx = 5; pady = 5
         self.geoSizer = wx.FlexGridSizer(nrow, ncol, padx, pady) 
         self.geoSizer.AddGrowableCol(0, 1)
         self.geoSizer.AddGrowableCol(1, 1)

--- a/hexrd/GUI/geReader.py
+++ b/hexrd/GUI/geReader.py
@@ -222,7 +222,7 @@ class geReaderPanel(wx.Panel):
         self.browse_spn = wx.SpinCtrl(self, wx.NewId(), min=0, initial=0)
         self.browse_inf = wx.TextCtrl(self, wx.NewId(), value='', 
                                       style=wx.RAISED_BORDER|wx.TE_READONLY)
-	self.sizer = wx.BoxSizer(wx.HORIZONTAL|wx.VERTICAL)
+        self.sizer = wx.BoxSizer(wx.HORIZONTAL)
         #
         #  Orientation
         #
@@ -884,25 +884,25 @@ class infoPanel(wx.Panel):
 
     def __makeSizers(self):
 	"""Lay out the interactors"""
-        nrow = 1; ncol = 2; padx = 5; pady = 5
-	self.fgsizer = wx.FlexGridSizer(nrow, ncol, padx, pady) # m x n, paddings
-	self.fgsizer.AddGrowableCol(1, 1)
-	#self.fgsizer.AddGrowableRow(num, proportion)
+        nrow = 2; ncol = 2; padx = 5; pady = 5
+        self.fgsizer = wx.FlexGridSizer(nrow, ncol, padx, pady) # m x n, paddings
+        self.fgsizer.AddGrowableCol(1, 1)
+        #self.fgsizer.AddGrowableRow(num, proportion)
 
-	self.fgsizer.Add(self.img_txt_lab, 0, wx.ALIGN_RIGHT|wx.RIGHT, 5)
-	self.fgsizer.Add(self.img_txt,     1, wx.EXPAND|wx.ALIGN_CENTER)
+        self.fgsizer.Add(self.img_txt_lab, 0, wx.ALIGN_RIGHT|wx.RIGHT, 5)
+        self.fgsizer.Add(self.img_txt,     1, wx.EXPAND|wx.ALIGN_CENTER)
 	
-	self.fgsizer.Add(self.drk_txt_lab, 0, wx.ALIGN_RIGHT|wx.RIGHT, 5)
-	self.fgsizer.Add(self.drk_txt,     1, wx.EXPAND|wx.ALIGN_CENTER)
+        self.fgsizer.Add(self.drk_txt_lab, 0, wx.ALIGN_RIGHT|wx.RIGHT, 5)
+        self.fgsizer.Add(self.drk_txt,     1, wx.EXPAND|wx.ALIGN_CENTER)
         #
         #  Main sizer
         #
-	self.sizer = wx.BoxSizer(wx.VERTICAL)
+        self.sizer = wx.BoxSizer(wx.VERTICAL)
 
-	self.sizer.Add(self.tbarSizer, 0, wx.EXPAND|wx.ALIGN_CENTER)
-	self.sizer.Add(self.fgsizer,   0, wx.EXPAND|wx.ALIGN_CENTER)
+        self.sizer.Add(self.tbarSizer, 0, wx.EXPAND|wx.ALIGN_CENTER)
+        self.sizer.Add(self.fgsizer,   0, wx.EXPAND|wx.ALIGN_CENTER)
 
-	return
+        return
     #
     # ============================== API
     #

--- a/hexrd/GUI/materialsPanel.py
+++ b/hexrd/GUI/materialsPanel.py
@@ -251,10 +251,10 @@ PANEL FOR ...
         #
         #  Space group
         #
-        nrow = 5; ncol = 3; padx = pady = 5;
+        nrow = 6; ncol = 3; padx = pady = 5;
         sgsizer = wx.FlexGridSizer(nrow, ncol, padx, pady) # m x n, paddings
-	sgsizer.AddGrowableCol(1, 1)
-	sgsizer.AddGrowableCol(2, 1)
+        sgsizer.AddGrowableCol(1, 1)
+        sgsizer.AddGrowableCol(2, 1)
         #  labels
         sgsizer.Add(self.sg_lab,   0, wx.ALIGN_CENTER)
         sgsizer.Add(self.hall_lab, 0, wx.ALIGN_CENTER)

--- a/hexrd/GUI/spotsPanel.py
+++ b/hexrd/GUI/spotsPanel.py
@@ -125,7 +125,7 @@ class spotsPanel(wx.Panel):
 
     def __makeSizers(self):
 	"""Lay out the interactors"""
-        nrow = 3; ncol = 2; padx = 5; pady = 5
+        nrow = 4; ncol = 2; padx = 5; pady = 5
         self.fgSizer = wx.FlexGridSizer(nrow, ncol, padx, pady) 
         self.fgSizer.AddGrowableCol(1, 1)
         #  1. material selector
@@ -143,8 +143,8 @@ class spotsPanel(wx.Panel):
 	#
         #  ========== Main Sizer
         #
-	self.sizer = wx.BoxSizer(wx.VERTICAL)
-	self.sizer.Add(self.tbarSizer, 0, wx.EXPAND|wx.ALIGN_CENTER)
+        self.sizer = wx.BoxSizer(wx.VERTICAL)
+        self.sizer.Add(self.tbarSizer, 0, wx.EXPAND|wx.ALIGN_CENTER)
         self.sizer.Add(self.fgSizer,   1, wx.ALIGN_RIGHT)
         self.sizer.Add(self.run,       0, wx.ALIGN_RIGHT)
 


### PR DESCRIPTION
fixes number of rows specified to numerous sizers. Change needed to launch hexrd with wx-2.9.4, which is the required version of wx for OS X 10.8
