### PR TITLE
removed qsize call for mac compat

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
 #    - numba
 #    - numbapro
     - numpy
-    - progressbar
+#    - progressbar
     - python
     - python.app # [osx]
     - pyyaml

--- a/hexrd/fitgrains.py
+++ b/hexrd/fitgrains.py
@@ -151,7 +151,7 @@ def get_job_queue(cfg):
                 )
             job_queue.put((i, grain_params))
     logger.info("fitting grains for %d orientations", n_quats)
-    return job_queue
+    return job_queue, n_quats
 
 
 def get_data(cfg, show_progress=False):
@@ -187,8 +187,8 @@ def get_data(cfg, show_progress=False):
 def fit_grains(cfg, force=False, show_progress=False):
     # load the data
     reader, pkwargs = get_data(cfg, show_progress)
-    job_queue = get_job_queue(cfg)
-    njobs = job_queue.qsize()
+    job_queue, njobs = get_job_queue(cfg)
+    #njobs = job_queue.qsize() # ...THIS CAUSES PROBLEMS ON MAC OS X
 
     ncpus = cfg.multiprocessing
     logger.info('running pullspots with %d processors', ncpus)


### PR DESCRIPTION
- Minor modification of the get_job_queue function to output number of jobs, hence eliminating the need to call qsize further on down the line, which creates problems on the mac.
- also _temporarily_ disabled progressbar req in the conda recipe to avoid firewall nonsense connecting to binstar.  works fine if installed with distutils anyhow.
