### PR TITLE
supports specifying disconnected omega ranges in config file

### DIFF
--- a/hexrd/config/imageseries.py
+++ b/hexrd/config/imageseries.py
@@ -1,6 +1,8 @@
 import glob
 import os
 
+import numpy as np
+
 from .config import Config
 
 
@@ -56,9 +58,34 @@ class OmegaConfig(Config):
 
 
     @property
+    def steps(self):
+        try:
+            res = []
+            res.extend(
+                np.round(np.abs((f-s)/d))
+                for s,f,d in zip(self.start, self.stop, self.step)
+                )
+        except TypeError:
+            res = np.round(np.abs((self.stop-self.start)/self.step))
+        return res
+
+
+    @property
     def stop(self):
         return self._cfg.get('image_series:omega:stop')
 
+
+    @property
+    def positions(self):
+        res = []
+        try:
+            for s,f,n in zip(self.start, self.stop, self.steps):
+                res.extend(np.linspace(s, f, n, endpoint=False))
+        except TypeError:
+            res.extend(
+                np.linspace(self.start, self.stop, self.steps, endpoint=False)
+                )
+        return res
 
 
 class ImageSeriesConfig(Config):

--- a/hexrd/config/tests/test_image_series.py
+++ b/hexrd/config/tests/test_image_series.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 
+import numpy as np
+
 from .common import TestConfig, test_data
 
 
@@ -34,6 +36,10 @@ image_series:
 image_series:
   file:
     ids: 2
+  omega:
+    start: [0, 60]
+    stop: [59.95, 119.95]
+    step: [0.249792, 0.249792]
 ---
 image_series:
   file:
@@ -212,3 +218,18 @@ class TestOmegaConfig(TestConfig):
             getattr, self.cfgs[0].image_series.omega, 'stop'
             )
         self.assertEqual(self.cfgs[2].image_series.omega.stop, 360)
+
+
+    def test_positions(self):
+        res = np.linspace(0, 360, 1440, endpoint=False).tolist()
+        self.assertArrayEqual(
+            self.cfgs[2].image_series.omega.positions,
+            res
+            )
+        res = []
+        res.extend(np.linspace(0, 59.95, 240, endpoint=False))
+        res.extend(np.linspace(60, 119.95, 240, endpoint=False))
+        self.assertArrayEqual(
+            self.cfgs[3].image_series.omega.positions,
+            res,
+            )

--- a/share/example_config.yml
+++ b/share/example_config.yml
@@ -3,7 +3,7 @@ analysis_name: sweep0 # defaults to analysis
 ## working directory defaults to current working directory
 ## all relative paths specified herein are assumed to be in the working_dir
 ## any files not in working_dir should be specified with an absolute path
-#working_dir: 
+#working_dir:
 
 multiprocessing: all # "all", or "half", or -1 means all but one, defaults to -1
 
@@ -19,10 +19,10 @@ image_series:
     start: 2
     #stop: 1440
     #step: 1
-  omega:
-    start: -60.0
-    step: 0.25
-    stop: 60.0
+  omega: # can specify disconnected omega ranges using lists
+    start: -60.0 # [-60, 120]
+    step: 0.25 # [0.25, 0.25]
+    stop: 60.0 # [60, 240]
   dark: RUBY_4537_medianDark
   flip: v # ~, v, h, hv, vh, cw, ccw
 


### PR DESCRIPTION
This pull request allows disconnected omega ranges to be specified in the config file.

@joelvbernier, is this sufficient for you to modify the analysis routines to support disconnected ranges? Ideally, one would just use `cfg.image_series.omega.positions`, but `start`, `stop`, `step`, and `steps` are also available if they are needed. The latter properties currently may return either lists or individual values, depending on how they are defined in the yml file. This could be tweaked so the config class always returns lists, it might simplify the API a little. 